### PR TITLE
Fix compiler error on uncasted objc_msgSend calls in Xcode 6.2

### DIFF
--- a/NSObject+NSCoding.m
+++ b/NSObject+NSCoding.m
@@ -164,8 +164,10 @@
       } else {
         @try {
           id value = [aDecoder decodeObjectForKey:name];
-          if (value != nil)
-            method_invoke(self, mt, value);
+          if (value != nil) {
+            void (*method_invokeTyped)(id self, Method mt, NSString *value) = (void*)method_invoke;
+            method_invokeTyped(self, mt, value);
+          }
 #if kNSCodingDebugLoging
           NSLog(@"Decode %@ %@  value:%@", NSStringFromClass(class), name, value);
 #endif


### PR DESCRIPTION
This fixes a compiler error in Xcode 6.2 by casting `objc_msgSend` calls, as stated in the comments of `objc/message.h`

```
/* Basic Messaging Primitives
 *
 * On some architectures, use objc_msgSend_stret for some struct return types.
 * On some architectures, use objc_msgSend_fpret for some float return types.
 * On some architectures, use objc_msgSend_fp2ret for some float return types.
 *
 * These functions must be cast to an appropriate function pointer type 
 * before being called. 
 */
#if !OBJC_OLD_DISPATCH_PROTOTYPES
OBJC_EXPORT void objc_msgSend(void /* id self, SEL op, ... */ )
    __OSX_AVAILABLE_STARTING(__MAC_10_0, __IPHONE_2_0);
OBJC_EXPORT void objc_msgSendSuper(void /* struct objc_super *super, SEL op, ... */ )
    __OSX_AVAILABLE_STARTING(__MAC_10_0, __IPHONE_2_0);
#else
```
